### PR TITLE
Minimal eval server patch

### DIFF
--- a/bin/rakudo.jvm.sh
+++ b/bin/rakudo.jvm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # default to sysperl
 PATH=/usr/local/bin:$PATH
@@ -24,9 +24,12 @@ export LANG=en_US.UTF-8
 
 # swap out the default runner with one that is ulimited
 # temporarily ignore memory ulimit. ## ulimit -v 2048576
+
+exec 3> >( ./perl6-eval-server -bind-stdin -cookie TESTCOOKIE -app perl6.jar )
+
 mv perl6 p6
 echo "#!/usr/bin/env perl" > perl6
-echo 'exec "ulimit -t 600; ./p6 @ARGV";' >> perl6
-chmod u+x perl6 p6
+echo 'exec "perl eval-client.pl TESTCOOKIE run @ARGV";' >> perl6
+chmod u+x perl6
 
 perl t/spec/test_summary rakudo.jvm 2>&1 | tee ../rakudo.jvm_summary.out


### PR DESCRIPTION
Known issues: requires bash, and does not support time or memory limits.
(Note that ulimit -t would be useless as that only handles CPU time, not
wall time.)
