### PR TITLE
Apply a memory limit to the non-JVM processes

### DIFF
--- a/bin/doit
+++ b/bin/doit
@@ -1,8 +1,18 @@
 #!/bin/sh
 ./bin/git.p5
+
+# do the JVM tasks first; aftewards we can apply a memory limit.
+# (the JVM *really* doesn't like it when it's run under a memory limit,
+# greedy thing)
+
+nice -20 ./bin/nqp.jvm.sh
+nice -20 ./bin/rakudo.jvm.sh
+
+# 4 GB should be enough for everyone!
+ulimit -v 4194304
+
 nice -20 ./bin/nqp.moar-jit.sh
 nice -20 ./bin/nqp.moar.sh
-nice -20 ./bin/nqp.jvm.sh
 nice -20 ./bin/nqp.js.sh
 nice -20 ./bin/nqp.parrot.sh
 
@@ -10,7 +20,6 @@ nice -20 ./bin/nqp.parrot.sh
 
 nice -20 ./bin/rakudo.moar.sh
 nice -20 ./bin/rakudo.moar-jit.sh
-nice -20 ./bin/rakudo.jvm.sh
 TEMPFILE="TEMPFILE"
 PASSFILE="perl6_pass_rates.csv"
 OUTPUT=`perl ./bin/cull`


### PR DESCRIPTION
Trying to be nice to everybody else on the machine where it runs :-)